### PR TITLE
Remove explicit CFLAGS defined by -march=native

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,12 +120,6 @@ else
     CFLAGS += -D__HAVE_TURBO__
   endif
 
-	# Get architecture
-  ARCH = $(shell uname -m)
-  ifneq ($(ARCH),x86_64)
-    CFLAGS += -msse2 -mfpmath=sse
-  endif
-
   # Release don't need debug symbols!
 	LDFLAGS += -s 
 


### PR DESCRIPTION
The -march=native parameter should specify the desired -msse2 -mfpmath=sse flags on supported CPUs.