### PR TITLE
Overridable cflags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ AC_PROG_CC_C_O
 AC_C_STRINGIZE
 AX_C___ATTRIBUTE__
 
-AX_CHECK_COMPILE_FLAG([-std=gnu11],[CFLAGS="-std=gnu11 "],[
+AX_CHECK_COMPILE_FLAG([-std=gnu11],[AM_CFLAGS="-std=gnu11"],[
 	echo "GNU C11 standard not supported? Aborting..."
 	exit 1
 ])
@@ -64,5 +64,7 @@ AC_C_RESTRICT
 AC_C_STRINGIZE
 
 AC_CONFIG_FILES([Makefile src/Makefile])
+
+AC_SUBST([AM_CFLAGS])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,19 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 #AC_CANONICAL_HOST
 
+# define default CFLAGS
+AC_ARG_ENABLE([debug],
+  AS_HELP_STRING([--enable-debug], [Enable T50 debug information]),
+  [DEFAULT_CFLAGS="-O0 -g -D__HAVE_DEBUG__"],
+  [DEFAULT_CFLAGS="-Ofast -march=native -s -DNDEBUG -fno-stack-protector"])
+
+AC_ARG_ENABLE([ansi],
+  AS_HELP_STRING([--enable-ansi], [Enable ANSI codes on T50 messages]),
+  [DEFAULT_CFLAGS+=" -DUSE_ANSI"],[])
+
+# overwrite CFLAGS only if they are not yet defined
+: ${CFLAGS="$DEFAULT_CFLAGS"}
+
 AC_PROG_CC
 AC_PROG_CC_C_O
 AC_C_STRINGIZE
@@ -30,15 +43,6 @@ AX_CHECK_COMPILE_FLAG([-std=gnu11],[AM_CFLAGS="-std=gnu11"],[
 ])
 
 AC_PROG_INSTALL
-
-AC_ARG_ENABLE([debug],
-  AS_HELP_STRING([--enable-debug], [Enable T50 debug information]),
-  [CFLAGS+=" -O0 -g -D__HAVE_DEBUG__ "],
-  [CFLAGS+=" -Ofast -march=native -s -DNDEBUG -fno-stack-protector "])
-
-AC_ARG_ENABLE([ansi],
-  AS_HELP_STRING([--enable-ansi], [Enable ANSI codes on T50 messages]),
-  [CFLAGS+=" -DUSE_ANSI "],[])
 
 # Define T50 compiler definitions
 AC_DEFINE([__HAVE_TURBO__],[1],[Use fork to spawn extra process])

--- a/configure.ac
+++ b/configure.ac
@@ -29,10 +29,6 @@ AX_CHECK_COMPILE_FLAG([-std=gnu11],[CFLAGS="-std=gnu11 "],[
 	exit 1
 ])
 
-AX_CHECK_COMPILE_FLAG([-mmovebe],[CFLAGS+="-mmovbe "],[
-	echo "*** No MOVBE instruction support ***"
-])
-
 AC_PROG_INSTALL
 
 AC_ARG_ENABLE([debug],


### PR DESCRIPTION
I've tried to improve the build system.  Unless CFLAGS is passed explicitly to ./configure it should behave exactly as before.  However, now the CFLAGS can be overwritten without needing to patch the build system (useful for Linux distributions). I've not yet run autoreconf, I'm leaving that to you in case you accept the request.

I've also removed the MOVBE support as it was buggy and should no longer be required now that -march=native was added.