### PR TITLE
Fix FTBFS on i386 caused by extra comma

### DIFF
--- a/src/randomizer.c
+++ b/src/randomizer.c
@@ -95,7 +95,7 @@ void SRANDOM(void)
       : "=r" (*(uint32_t *)_seed), 
         "=r" (*((uint32_t *)_seed + 1)), 
         "=r" (*((uint32_t *)_seed + 2)), 
-        "=r" (*((uint32_t *)_seed + 3)), 
+        "=r" (*((uint32_t *)_seed + 3))
       : : "cc"
     );
 #endif


### PR DESCRIPTION
Bug detected on debian
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=865785

Please bear in mind that this is a very critical bug and the acceptance of this PR should trigger a new t50 release.